### PR TITLE
major bugfix + mirror analytics.js transport selection & implementation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ https://www.thyngster.com/universal-analytics-plugin-dual-tracking/
 ga('create', 'UA-286304-123', 'auto');
 ga('require', 'dualtracking', 'http://www.yourdomain.com/js/dualtracking.js', {
     property: 'UA-123123123213-11',
-    debug: true,
-    transport: 'image'
+    debug: true
 });
 ga('send', 'pageview');

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -67,8 +67,6 @@
 				return sendHit( hitPayload, hitCallback, 'xhr' );
 
 			default:
-			 
-			 console.warn( hitPayload.length );
 
 				// Throw error if payload is bigger than 8KB.
 				if( hitPayload.length > 8192 )

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -60,7 +60,7 @@
 
 			case 'beacon':
 				if( window.navigator.sendBeacon
-				    && window.navigator.sendBeacon( urlBase, hitPayload ) ){
+				 && window.navigator.sendBeacon( urlBase, hitPayload ) ){
 					hitCallback();
 					return true;
 				}
@@ -104,14 +104,12 @@
 		var originalSendHitTask = this.tracker.get('sendHitTask');
 		this.tracker.set('sendHitTask', (function(model) {
 			originalSendHitTask(model);
-			try{
-				var payLoad = model.get('hitPayload');
-				var data = (payLoad).replace(/(^\?)/,'').split("&").map(function(n){return n = n.split("="),this[n[0]] = n[1],this}.bind({}))[0];
-				data.tid = this.property;
-				var newPayload = Object.keys(data).map(function(key) { return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]); }).join('&');
-				sendHit( newPayload, null, tracker.get('transport') );
-				log('info','Sent dual hit to '+this.property);
-			}catch(ex){}
+			var payLoad = model.get('hitPayload');
+			var data = (payLoad).replace(/(^\?)/,'').split("&").map(function(n){return n = n.split("="),this[n[0]] = n[1],this}.bind({}))[0];
+			data.tid = this.property;
+			var newPayload = Object.keys(data).map(function(key) { return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]); }).join('&');
+			sendHit( newPayload, null, tracker.get('transport') );
+			log('info','Sent dual hit to '+this.property);
 		}).bind(this) );
 	};
 

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -6,6 +6,88 @@
 	var isDebug;
 
 	/**
+	 * Error constructor copied from analytics.js.
+	 * @param {number} payloadSize - Payload size, in bytes.
+	 * @constructor
+	 */
+	function UaHitPayloadTooBigError( payloadSize ){
+		this.name    = "len";
+		this.message = payloadSize + "-8192"
+	}
+
+
+	/**
+	 * Send UA hit using same logic as analytics.js. Tries to send data to GA using a number of transport methods: preferring first sendBeacon, then XHR, then image pixel.  (Explicitly defining transport=xhr will avoid using sendBeacon, and setting transport=image will avoid both sendBeacon and XHR, and image will always be the last resort.)  Throws error if payload greater than 8KB.   
+	 * @param {string} hitPayload - Hit data, in Measurement Protocol format.
+	 * @param {Function} hitCallback - @see https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#hitCallback
+	 * @param {string} [transportMethod] - Optional. Should be one of: "image", "xhr" or "beacon". If blank or invalid value, will automatically select a method based on payload size and browser.
+	 * @returns {boolean|} - True if successful, otherwise undefined to reflect unknown outcome of 'image' method.
+	 * @throws UaHitPayloadTooBigError
+	 */
+	function sendHit( hitPayload, hitCallback, transportMethod ){
+
+		var img, xhr, urlBase = 'https://www.google-analytics.com/collect';
+
+		hitCallback = hitCallback || function(){};
+
+		switch( transportMethod ){
+
+			case 'image':
+				img        = document.createElement( "img" );
+				img.width  = 1;
+				img.height = 1;
+				img.src    = urlBase + "?" + hitPayload;
+				img.onload = img.onerror = function(){
+					img.onload  = img.onerror = null;
+					hitCallback();
+				};
+				return;
+
+			case 'xhr':
+				if( !window.XMLHttpRequest || !("withCredentials" in (xhr = new window.XMLHttpRequest)) )
+					return sendHit( hitPayload, hitCallback, 'image' );
+				xhr.open( "POST", urlBase, true );
+				xhr.withCredentials = true;
+				xhr.setRequestHeader( "Content-Type", "text/plain" );
+				xhr.onreadystatechange = function(){
+					if( 4 == xhr.readyState ){
+						hitCallback();
+						xhr = null;
+					}
+				};
+				xhr.send( hitPayload );
+				return true;
+
+			case 'beacon':
+				if( window.navigator.sendBeacon
+				    && window.navigator.sendBeacon( urlBase, hitPayload ) ){
+					hitCallback();
+					return true;
+				}
+				return sendHit( hitPayload, hitCallback, 'xhr' );
+
+			default:
+			 
+			 console.warn( hitPayload.length );
+
+				// Throw error if payload is bigger than 8KB.
+				if( hitPayload.length > 8192 )
+					throw new UaHitPayloadTooBigError( hitPayload.length );
+
+				// If payload is bigger than 2KB, try using sendBeacon or XHR.
+				if( hitPayload.length > 2036
+				    && ( sendHit( hitPayload, hitCallback, 'beacon' )
+				      || sendHit( hitPayload, hitCallback, 'xhr' ) ) )
+					return true;
+
+				// If payload is no bigger than 2KB or if both sendBeacon and  
+				//   XHR methods are not available, use image method.
+				return sendHit( hitPayload, hitCallback, 'image' );
+		}
+
+	}
+
+	/**
 	 * The plugin constructor. Called by analytics.js with the `new` keyword.
 	 * @param {Object} tracker - The UA tracker object.
 	 * @param {Object} config - The last argument passed to `ga('require', 'dualtracking', ... )`.
@@ -17,24 +99,10 @@
 		log('info','Initializing...');
 		this.tracker = tracker;
 		this.property = config.property;
-		this.transport = config.transport || tracker.get('transport') || 'beacon';
+		this.transport = config.transport || tracker.get('transport');
 		
 		if(!this.property || !this.property.match(/^UA-([0-9]*)-([0-9]{1,2}$)/))
 			return log('error','property id, needs to be set and have the following format UA-XXXXXXXX-YY');
-		
-		if( this.transport!='image' && this.transport!='beacon' && this.transport!='xhr' )
-			return log('error','"'+this.transport+'" is an invalid value for transport.');
-		
-		if( this.transport=='beacon' && !navigator.sendBeacon ){
-			log( 'info', 'Browser does not support sendBeacon; defaulting to transport=image.' );
-			this.transport = 'image';
-		}
-		
-		//TODO: implement xhr method
-		if( this.transport=='xhr' ){
-			log('warn','XHR not supported yet; defaulting to transport=image.');
-			this.transport = 'image';
-		}
 
 		var originalSendHitTask = this.tracker.get('sendHitTask');
 		this.tracker.set('sendHitTask', (function(model) {
@@ -44,15 +112,7 @@
 				var data = (payLoad).replace(/(^\?)/,'').split("&").map(function(n){return n = n.split("="),this[n[0]] = n[1],this}.bind({}))[0];
 				data.tid = this.property;
 				var newPayload = Object.keys(data).map(function(key) { return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]); }).join('&');
-				if(this.transport=="image"){
-					var i=new Image(1,1);
-					i.src="https://www.google-analytics.com/collect"+"?"+newPayload;i.onload=function(){}
-				}else if(this.transport=="beacon"){
-					navigator.sendBeacon("https://www.google-analytics.com/collect", newPayload);
-				}else{
-					//TODO: implement xhr method
-					log('error','TODO: implement XHR method.');
-				}
+				sendHit( newPayload, null, this.transport );
 				log('info','Sent dual hit to '+this.property);
 			}catch(ex){}
 		}).bind(this) );

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -15,8 +15,20 @@
 		
 		if(!this.property || !this.property.match(/^UA-([0-9]*)-([0-9]{1,2}$)/))
 			return log('error','property id, needs to be set and have the following format UA-XXXXXXXX-YY');
+		
 		if( this.transport!='image' && this.transport!='beacon' && this.transport!='xhr' )
 			return log('error','"'+this.transport+'" is an invalid value for transport.');
+		
+		if( this.transport=='beacon' && !navigator.sendBeacon ){
+			log( 'info', 'Browser does not support sendBeacon; defaulting to transport=image.' );
+			this.transport = 'image';
+		}
+		
+		//TODO: implement xhr method
+		if( this.transport=='xhr' ){
+			log('warn','XHR not supported yet; defaulting to transport=image.');
+			this.transport = 'image';
+		}
 
 		var originalSendHitTask = this.tracker.get('sendHitTask');
 		this.tracker.set('sendHitTask', (function(model) {
@@ -33,7 +45,7 @@
 					navigator.sendBeacon("https://www.google-analytics.com/collect", newPayload);
 				}else{
 					//TODO: implement xhr method
-					log('TODO: implement XHR method.');
+					log('error','TODO: implement XHR method.');
 				}
 				log('info','Sent dual hit to '+this.property);
 			}catch(ex){}

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -5,6 +5,12 @@
 	
 	var isDebug;
 
+	/**
+	 * The plugin constructor. Called by analytics.js with the `new` keyword.
+	 * @param {Object} tracker - The UA tracker object.
+	 * @param {Object} config - The last argument passed to `ga('require', 'dualtracking', ... )`.
+	 * @constructor
+	 */
 	var DualTracking = function(tracker, config) {
 		config = config || {};
 		isDebug = config.debug;

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -99,7 +99,6 @@
 		log('info','Initializing...');
 		this.tracker = tracker;
 		this.property = config.property;
-		this.transport = config.transport || tracker.get('transport');
 		
 		if(!this.property || !this.property.match(/^UA-([0-9]*)-([0-9]{1,2}$)/))
 			return log('error','property id, needs to be set and have the following format UA-XXXXXXXX-YY');
@@ -112,7 +111,7 @@
 				var data = (payLoad).replace(/(^\?)/,'').split("&").map(function(n){return n = n.split("="),this[n[0]] = n[1],this}.bind({}))[0];
 				data.tid = this.property;
 				var newPayload = Object.keys(data).map(function(key) { return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]); }).join('&');
-				sendHit( newPayload, null, this.transport );
+				sendHit( newPayload, null, tracker.get('transport') );
 				log('info','Sent dual hit to '+this.property);
 			}catch(ex){}
 		}).bind(this) );

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -107,7 +107,7 @@
 			var payLoad = model.get('hitPayload');
 			var data = (payLoad).replace(/(^\?)/,'').split("&").map(function(n){return n = n.split("="),this[n[0]] = n[1],this}.bind({}))[0];
 			data.tid = this.property;
-			var newPayload = Object.keys(data).map(function(key) { return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]); }).join('&');
+			var newPayload = Object.keys(data).map(function(key) { return key + '=' + data[key]; }).join('&');
 			sendHit( newPayload, null, tracker.get('transport') );
 			log('info','Sent dual hit to '+this.property);
 		}).bind(this) );


### PR DESCRIPTION
- default to transport=image in browsers lacking sendBeacon support
- default to transport=image for unimplemented XHR method
