### PR TITLE
XHR method, exclude fields from secondary payload, polyfills

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,5 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 thyngster
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 This started here:
 https://www.thyngster.com/universal-analytics-plugin-dual-tracking/
 
-I added a few bits&bobs.
+And is elaborated upon here:
+http://www.flesheatingarthropods.org/double-tracking-in-ga-part1/
+http://www.flesheatingarthropods.org/double-tracking-in-ga-part2/
+http://www.flesheatingarthropods.org/double-tracking-in-ga-part3/
 
 # What is it for
 This will send GA tracking calls to a second property without using named trackers and configuring each call twice.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This started here:
 https://www.thyngster.com/universal-analytics-plugin-dual-tracking/
 
 And is elaborated upon here:
-*http://www.flesheatingarthropods.org/double-tracking-in-ga-part1/
-*http://www.flesheatingarthropods.org/double-tracking-in-ga-part2/
-*http://www.flesheatingarthropods.org/double-tracking-in-ga-part3/
+* http://www.flesheatingarthropods.org/double-tracking-in-ga-part1/
+* http://www.flesheatingarthropods.org/double-tracking-in-ga-part2/
+* http://www.flesheatingarthropods.org/double-tracking-in-ga-part3/
 
 # What is it for
 This will send GA tracking calls to a second property without using named trackers and configuring each call twice.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This started here:
 https://www.thyngster.com/universal-analytics-plugin-dual-tracking/
 
 And is elaborated upon here:
-http://www.flesheatingarthropods.org/double-tracking-in-ga-part1/
-http://www.flesheatingarthropods.org/double-tracking-in-ga-part2/
-http://www.flesheatingarthropods.org/double-tracking-in-ga-part3/
+*http://www.flesheatingarthropods.org/double-tracking-in-ga-part1/
+*http://www.flesheatingarthropods.org/double-tracking-in-ga-part2/
+*http://www.flesheatingarthropods.org/double-tracking-in-ga-part3/
 
 # What is it for
 This will send GA tracking calls to a second property without using named trackers and configuring each call twice.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
-# universal-analytics-dual-tracking-plugin
+# Universal Analytics Dual Tracking Plugin
 Repository for the online Google Analytics hackaton
-Hackathon Post URL: 
+Hackathon Post URL:
 https://www.thyngster.com/universal-analytics-plugin-dual-tracking/
 
+# What is it for
+This will send GA tracking calls to a second property without using named trackers and configuring each call twice.
+It also allows to overwrite or exlude fields in the secondary call via the "fields" object in configuration.
+
+# Configuration
 
 ```javascript
 ga('create', 'UA-286304-123', 'auto');
 ga('require', 'dualtracking', 'http://www.yourdomain.com/js/dualtracking.js', {
     property: 'UA-123123123213-11',
     debug: true,
-    transport: 'image'
+    transport: 'image',
+    fields: {
+      'userId':null
+    }
 });
-ga('dualtracking:doDualTracking');
 ga('send', 'pageview');
+
+This would send a call to UA-123123123213-11 while unsetting the userId field. Be aware that if you unset a required field the tracking call might not work.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Universal Analytics Dual Tracking Plugin
-Repository for the online Google Analytics hackaton
-Hackathon Post URL:
+
+This started here:
 https://www.thyngster.com/universal-analytics-plugin-dual-tracking/
+
+I added a few bits&bobs.
 
 # What is it for
 This will send GA tracking calls to a second property without using named trackers and configuring each call twice.
@@ -20,5 +22,11 @@ ga('require', 'dualtracking', 'http://www.yourdomain.com/js/dualtracking.js', {
     }
 });
 ga('send', 'pageview');
+```
 
 This would send a call to UA-123123123213-11 while unsetting the userId field. Be aware that if you unset a required field the tracking call might not work.
+
+# Known Caveats
+
+- does not work with named trackers
+- not heavily tested

--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ The plugin has the following configuration options:
 
 # Known Caveats
 
-- does not work with named trackers
+- ~~does not work with named trackers~~ (stupid me. Remember to prepend the tracker name to the require call)
 - not heavily tested

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ ga('send', 'pageview');
 
 This would send a call to UA-123123123213-11 while unsetting the userId field. Be aware that if you unset a required field the tracking call might not work.
 
+# Valid options
+
+The plugin has the following configuration options:
+
+* property (string ) - The UAID for the secondary property
+* endpoint (string)  - The URL the data is send to (defaults to "https://www.google-analytics.com/collect";)
+* debug    (bool)    - prints status messages to the browser console
+* fields   (object)  - an optional JSON object with key/value pairs. Corresponding fields are overwritten in the payload or removed if the new value is null
+
 # Known Caveats
 
 - does not work with named trackers

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -1,58 +1,181 @@
-    /**
-	 *  Universal Analytics Dual Tracking Plugin
-	 */
-(function(){
-	function providePlugin(pluginName, pluginConstructor) {
-	  var ga = window[window['GoogleAnalyticsObject'] || 'ga'];
-	  if (typeof ga == 'function') {
-		ga('provide', pluginName, pluginConstructor);
-	  }
-	}
+/**
+ *  Universal Analytics Dual Tracking Plugin
+ *  Copyright (c) 2016 thyngster (David Vallejo – www.thyngster.com)
+ *  Stephen Harris https://github.com/smhmic
+ *  Eike Pierstorff flesheatingarthropods.org
+ */
 
-	var DualTracking = function(tracker, config) {
-	  this.tracker = tracker;
-	  this.property = config.property, 
-	  this.isDebug = config.debug;
-	  this.transport = config.transport || 'beacon';
-	};
-	
+(function() {
+    function providePlugin(pluginName, pluginConstructor) {
+        var ga = window[window['GoogleAnalyticsObject'] || 'ga'];
+        if (typeof ga == 'function') {
+            ga('provide', pluginName, pluginConstructor);
+        }
+    }
+
+    var DualTracking = function(tracker, config) {
+        this.tracker = tracker;
+        this.property = config.property;
+        this.fields = config.fields || {};
+        this.gaEndpoint = "https://www.google-analytics.com/collect";
+
+				this.isDebug = config.debug;
+        if (!window.console) {
+            this.isDebug = false;
+        }
+
+        this.transport = config.transport || 'beacon';
+        var validTransportOptions = ['image', 'beacon', 'xhr'];
+        if (validTransportOptions.indexOf(this.transport) == -1) {
+            this.transport = "image";
+            this.debugMessage('info', 'Invalid transport option; defaulting to transport image');
+        }
+        if (this.transport == 'beacon' && !navigator.sendBeacon) {
+            this.transport = "image";
+            this.debugMessage('info', 'Browser does not support sendBeacon; defaulting to transport image');
+        }
+
+				this.doDualTracking();
+    };
+
     /**
-	 * 
-	 */
-	DualTracking.prototype.doDualTracking = function() {
-		this.debugMessage('Initializing the dualtracking plugin for GA');  
-		if(!this.property || !this.property.match(/^UA-([0-9]*)-([0-9]{1,2}$)/)){
-			this.debugMessage('dualtracking plugin: property id, needs to be set and have the following format UA-XXXXXXXX-YY');  
-			return 0;			
-		}else{
-			window.__gaDualTracking = {};
-			window.__gaDualTracking.property = this.property;
-			window.__gaDualTracking.transport = this.transport;
+     * dual tracking main function
+     */
+    DualTracking.prototype.doDualTracking = function() {
+
+        this.debugMessage('Initializing the dualtracking plugin for GA');
+        if (!this.property || !this.property.match(/^UA-([0-9]*)-([0-9]{1,2}$)/)) {
+            this.debugMessage('dualtracking plugin: property id, needs to be set and have the following format UA-XXXXXXXX-YY');
+            return 0;
+        }
+
+        var originalSendHitTask = this.tracker.get('sendHitTask');
+				var that = this; // make this accessible in the following closure
+        this.tracker.set('sendHitTask', function(model) {
+            var payLoad = model.get('hitPayload');
+
+						// huge payloads - e.g. if you do EEC with large product lists - are better sent via
+						// xhr post request. AFAIK the original request selects best transport method automatically
+						if(that.debug && that.transport != "xhr") {
+							  var len = lengthInUtf8Bytes(payload);
+								if(len > 2047) {
+										that.debugMessage('info', 'Huge payload ( ~' + len + ' chars), consider setting transport to xhr');
+								}
+						}
+
+						// send unmodified request to original tracker
+						originalSendHitTask(model);
+
+						// get the (modified) payload for the duplicate tracker
+						var data = that.deconstructPayload(payLoad);
+            var newPayload = that.reconstructPayload(data);
+
+            if (that.transport == "image") {
+                var i = new Image(1, 1);
+                i.src = [that.gaEndpoint,newPayload].join("?");
+                i.onload = function() {
+                    that.debugMessage('info', 'Image request sent');
+                    return;
+                }
+            } 	else if (that.transport == "beacon") { //  TODO send newPayload as data, not via the url
+							  navigator.sendBeacon([that.gaEndpoint,newPayload].join("?"),'');
+                that.debugMessage('info', 'Beacon sent');
+            } else if (that.transport == "xhr") {
+
+								var xhr = new XMLHttpRequest();
+                xhr.open('POST', that.gaEndpoint, true);
+                xhr.send(newPayload);
+
+								// evaluate async response
+                xhr.onload = function() {
+                    var response = xhr.response;
+                    if (xhr.response.length == 0) {
+                        that.debugMessage('error', 'Empty response');
+                    } else {
+                        that.debugMessage('info', 'XHR request sent');
+                    }
+                };
+								// if it did not work at all
+                xhr.onerror = function(e) {
+                    that.debugMessage('error', 'Network error, no data sent');
+                };
+            }
+
+        });
+
+    }
+
+    /**
+     * disassemble the models' payload into key/value pairs
+     */
+    DualTracking.prototype.deconstructPayload = function(payLoad) {
+
+			 that.debugMessage("debug","Running deconstructPayload");
+
+			 // remove leading question mark, split by ampersand and map to
+			 // function that splits into key/value pairs
+        var data = (payLoad).replace(/(^\?)/, '').split("&").map(function(n) {
+            return n = n.split("="), this[n[0]] = n[1], this
+        }.bind({}))[0];
+
+        return data;
+    }
+
+    /**
+     * reassemble a payload package after overwriting the configured values
+     * values for the duplicate tracker
+     */
+    DualTracking.prototype.reconstructPayload = function(data) {
+        // setting the property id for the duplicate tracker
+        data.tid = this.property;
+
+				// replace values if they are present, delete from data if they are set to null
+        var fields = this.fields;
+
+				var keys = Object.keys(fields);
+
+				keys.forEach(function(key) {
+				    if(typeof fields[key] != "undefined") {
+				      if(fields[key] == null) {
+				          delete data[key];
+									// this.debugMessage('info', 'Removed key' + key + ' with value' + data[key] + " from payload");
+				      } else {
+								prevValue = data[key];
+								data[key] = fields[key];
+								// this.debugMessage('info', 'For key' + key + ' changed value ' + oldValue + ' to '  + data[key] + " in payload");
+				      }
+				    }
+				});
+
+				// Object.keys so not to enumerate properties in the prototype  chain
+        var newPayload = Object.keys(data).map(function(key) {
+            return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]);
+        }).join('&');
+
+        return newPayload;
+    }
+
+    /**
+     * Displays a debug message in the console, if debugging is enabled.
+     */
+    DualTracking.prototype.debugMessage = function(type, message) {
+        if (!this.isDebug) return;
+        if (arguments.length == 1) {
+            message = arguments[0];
+            type = "debug";
+        }
+
+        console[type]('[DualTracking]', message);
+    };
+
+    /**
+		 * from here http://stackoverflow.com/a/5515960/761212
+		 */
+		DualTracking.prototype.lengthInUtf8Bytes = function(str) {
+		  // Matches only the 10.. bytes that are non-initial characters in a multi-byte sequence.
+		  var m = encodeURIComponent(str).match(/%[89ABab]/g);
+		  return str.length + (m ? m.length : 0);
 		}
-		
-		var originalSendHitTask = this.tracker.get('sendHitTask');
-		this.tracker.set('sendHitTask', function(model) {
-			var payLoad = model.get('hitPayload');	
-			var data = (payLoad).replace(/(^\?)/,'').split("&").map(function(n){return n = n.split("="),this[n[0]] = n[1],this}.bind({}))[0];
-			data.tid = window.__gaDualTracking.property;
-			originalSendHitTask(model);
-			var newPayload = Object.keys(data).map(function(key) { return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]); }).join('&');
-			if(__gaDualTracking.transport=="image"){
-				var i=new Image(1,1);	
-				i.src="https://www.google-analytics.com/collect"+"?"+newPayload;i.onload=function(){return;}				
-			}else if(__gaDualTracking.transport=="beacon"){
-				navigator.sendBeacon("https://www.google-analytics.com/collect", newPayload);
-			}			
-		});
-	}
 
-	/**
-	 * Displays a debug message in the console, if debugging is enabled.
-	 */
-	DualTracking.prototype.debugMessage = function(message) {
-	  if (!this.isDebug) return;
-	  if (console) console.debug(message);
-	};
-
-	providePlugin('dualtracking', DualTracking);  	
+    providePlugin('dualtracking', DualTracking);
 })();

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -107,7 +107,7 @@
    */
   DualTracking.prototype.deconstructPayload = function(payLoad) {
 
-    that.debugMessage("debug", "Running deconstructPayload");
+    this.debugMessage("debug", "Running deconstructPayload");
 
     // remove leading question mark, split by ampersand and map to
     // function that splits into key/value pairs

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -8,10 +8,10 @@
  *  Eike Pierstorff flesheatingarthropods.org
  *  https://github.com/flesheatingarthropods/universal-analytics-dual-tracking-plugin
  *
- *  Array methods polyfills  by  Independent software
+ *  Array methods polyfills  from here (Independent software)
  *  http://www.independent-software.com/about-independent-software/
  *
- * Object.keys polyfill from here: https://gist.github.com/jonfalcon/4715325
+ *  Object.keys polyfill from here: https://gist.github.com/jonfalcon/4715325
  */
 
 (function() {
@@ -27,7 +27,7 @@
 
     this.property = config.property;
     this.fields = config.fields || {};
-    this.gaEndpoint = "https://www.google-analytics.com/collect";
+    this.endpoint = config.endpoint || "https://www.google-analytics.com/collect";
 
     this.isDebug = config.debug;
     if (!window.console) {
@@ -84,15 +84,15 @@
 
       if (this.transport == "image") {
         var i = new Image(1, 1);
-        i.src = [this.gaEndpoint, newPayload].join("?");
+        i.src = [this.endpoint, newPayload].join("?");
         this.log('info', 'Image request sent');
       } else if (this.transport == "beacon") { //  TODO send newPayload as data, not via the url
-        navigator.sendBeacon([this.gaEndpoint, newPayload].join("?"), '');
+        navigator.sendBeacon([this.endpoint, newPayload].join("?"), '');
         this.log('info', 'Beacon sent');
       } else if (this.transport == "xhr") {
 
         var xhr = new XMLHttpRequest();
-        xhr.open('POST', this.gaEndpoint, true);
+        xhr.open('POST', this.endpoint, true);
         xhr.send(newPayload);
 
         // evaluate async response

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -10,6 +10,8 @@
  *
  *  Array methods polyfills  by  Independent software
  *  http://www.independent-software.com/about-independent-software/
+ *
+ * Object.keys polyfill from here: https://gist.github.com/jonfalcon/4715325
  */
 
 (function() {
@@ -280,6 +282,44 @@
     };
   }
 
+  /**
+   * Polyfill for Object.keys
+   *
+   * @see: https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Object/keys
+   */
+  if (!Object.keys) {
+    Object.keys = (function () {
+      var hasOwnProperty = Object.prototype.hasOwnProperty,
+          hasDontEnumBug = !({toString: null}).propertyIsEnumerable('toString'),
+          dontEnums = [
+            'toString',
+            'toLocaleString',
+            'valueOf',
+            'hasOwnProperty',
+            'isPrototypeOf',
+            'propertyIsEnumerable',
+            'constructor'
+          ],
+          dontEnumsLength = dontEnums.length;
+
+      return function (obj) {
+        if (typeof obj !== 'object' && typeof obj !== 'function' || obj === null) throw new TypeError('Object.keys called on non-object');
+
+        var result = [];
+
+        for (var prop in obj) {
+          if (hasOwnProperty.call(obj, prop)) result.push(prop);
+        }
+
+        if (hasDontEnumBug) {
+          for (var i=0; i < dontEnumsLength; i++) {
+            if (hasOwnProperty.call(obj, dontEnums[i])) result.push(dontEnums[i]);
+          }
+        }
+        return result;
+      }
+    })()
+  };
 
   /**
    * from here http://stackoverflow.com/a/5515960/761212

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -1,8 +1,15 @@
 /**
  *  Universal Analytics Dual Tracking Plugin
- *  Copyright (c) 2016 thyngster (David Vallejo – www.thyngster.com)
+ *  Copyright (c) for the original version 2016 thyngster (David Vallejo – www.thyngster.com)
+ *  https://www.thyngster.com/universal-analytics-plugin-dual-tracking/
+ *
  *  Stephen Harris https://github.com/smhmic
+ *
  *  Eike Pierstorff flesheatingarthropods.org
+ *  https://github.com/flesheatingarthropods/universal-analytics-dual-tracking-plugin
+ *
+ *  Array methods polyfills written by  Independent software
+ *  http://www.independent-software.com/about-independent-software/
  */
 (function() {
   function providePlugin(pluginName, pluginConstructor) {

--- a/dualtracking.js
+++ b/dualtracking.js
@@ -4,178 +4,171 @@
  *  Stephen Harris https://github.com/smhmic
  *  Eike Pierstorff flesheatingarthropods.org
  */
-
 (function() {
-    function providePlugin(pluginName, pluginConstructor) {
-        var ga = window[window['GoogleAnalyticsObject'] || 'ga'];
-        if (typeof ga == 'function') {
-            ga('provide', pluginName, pluginConstructor);
-        }
+  function providePlugin(pluginName, pluginConstructor) {
+    var ga = window[window['GoogleAnalyticsObject'] || 'ga'];
+    if (typeof ga == 'function') {
+      ga('provide', pluginName, pluginConstructor);
+    }
+  }
+
+  var DualTracking = function(tracker, config) {
+    this.tracker = tracker;
+    this.property = config.property;
+    this.fields = config.fields || {};
+    this.gaEndpoint = "https://www.google-analytics.com/collect";
+
+    this.isDebug = config.debug;
+    if (!window.console) {
+      this.isDebug = false;
     }
 
-    var DualTracking = function(tracker, config) {
-        this.tracker = tracker;
-        this.property = config.property;
-        this.fields = config.fields || {};
-        this.gaEndpoint = "https://www.google-analytics.com/collect";
-
-				this.isDebug = config.debug;
-        if (!window.console) {
-            this.isDebug = false;
-        }
-
-        this.transport = config.transport || 'beacon';
-        var validTransportOptions = ['image', 'beacon', 'xhr'];
-        if (validTransportOptions.indexOf(this.transport) == -1) {
-            this.transport = "image";
-            this.debugMessage('info', 'Invalid transport option; defaulting to transport image');
-        }
-        if (this.transport == 'beacon' && !navigator.sendBeacon) {
-            this.transport = "image";
-            this.debugMessage('info', 'Browser does not support sendBeacon; defaulting to transport image');
-        }
-
-				this.doDualTracking();
-    };
-
-    /**
-     * dual tracking main function
-     */
-    DualTracking.prototype.doDualTracking = function() {
-
-        this.debugMessage('Initializing the dualtracking plugin for GA');
-        if (!this.property || !this.property.match(/^UA-([0-9]*)-([0-9]{1,2}$)/)) {
-            this.debugMessage('dualtracking plugin: property id, needs to be set and have the following format UA-XXXXXXXX-YY');
-            return 0;
-        }
-
-        var originalSendHitTask = this.tracker.get('sendHitTask');
-				var that = this; // make this accessible in the following closure
-        this.tracker.set('sendHitTask', function(model) {
-            var payLoad = model.get('hitPayload');
-
-						// huge payloads - e.g. if you do EEC with large product lists - are better sent via
-						// xhr post request. AFAIK the original request selects best transport method automatically
-						if(that.debug && that.transport != "xhr") {
-							  var len = lengthInUtf8Bytes(payload);
-								if(len > 2047) {
-										that.debugMessage('info', 'Huge payload ( ~' + len + ' chars), consider setting transport to xhr');
-								}
-						}
-
-						// send unmodified request to original tracker
-						originalSendHitTask(model);
-
-						// get the (modified) payload for the duplicate tracker
-						var data = that.deconstructPayload(payLoad);
-            var newPayload = that.reconstructPayload(data);
-
-            if (that.transport == "image") {
-                var i = new Image(1, 1);
-                i.src = [that.gaEndpoint,newPayload].join("?");
-                i.onload = function() {
-                    that.debugMessage('info', 'Image request sent');
-                    return;
-                }
-            } 	else if (that.transport == "beacon") { //  TODO send newPayload as data, not via the url
-							  navigator.sendBeacon([that.gaEndpoint,newPayload].join("?"),'');
-                that.debugMessage('info', 'Beacon sent');
-            } else if (that.transport == "xhr") {
-
-								var xhr = new XMLHttpRequest();
-                xhr.open('POST', that.gaEndpoint, true);
-                xhr.send(newPayload);
-
-								// evaluate async response
-                xhr.onload = function() {
-                    var response = xhr.response;
-                    if (xhr.response.length == 0) {
-                        that.debugMessage('error', 'Empty response');
-                    } else {
-                        that.debugMessage('info', 'XHR request sent');
-                    }
-                };
-								// if it did not work at all
-                xhr.onerror = function(e) {
-                    that.debugMessage('error', 'Network error, no data sent');
-                };
-            }
-
-        });
-
+    this.transport = config.transport || 'beacon';
+    var validTransportOptions = ['image', 'beacon', 'xhr'];
+    if (validTransportOptions.indexOf(this.transport) == -1) {
+      this.transport = "image";
+      this.debugMessage('info', 'Invalid transport option; defaulting to transport image');
+    }
+    if (this.transport == 'beacon' && !navigator.sendBeacon) {
+      this.transport = "image";
+      this.debugMessage('info', 'Browser does not support sendBeacon; defaulting to transport image');
     }
 
-    /**
-     * disassemble the models' payload into key/value pairs
-     */
-    DualTracking.prototype.deconstructPayload = function(payLoad) {
+    this.doDualTracking();
+  };
 
-			 that.debugMessage("debug","Running deconstructPayload");
+  /**
+   * dual tracking main function
+   */
+  DualTracking.prototype.doDualTracking = function() {
 
-			 // remove leading question mark, split by ampersand and map to
-			 // function that splits into key/value pairs
-        var data = (payLoad).replace(/(^\?)/, '').split("&").map(function(n) {
-            return n = n.split("="), this[n[0]] = n[1], this
-        }.bind({}))[0];
-
-        return data;
+    this.debugMessage('Initializing the dualtracking plugin for GA');
+    if (!this.property || !this.property.match(/^UA-([0-9]*)-([0-9]{1,2}$)/)) {
+      this.debugMessage('dualtracking plugin: property id, needs to be set and have the following format UA-XXXXXXXX-YY');
+      return 0;
     }
 
-    /**
-     * reassemble a payload package after overwriting the configured values
-     * values for the duplicate tracker
-     */
-    DualTracking.prototype.reconstructPayload = function(data) {
-        // setting the property id for the duplicate tracker
-        data.tid = this.property;
+    var originalSendHitTask = this.tracker.get('sendHitTask');
+    var that = this; // make this accessible in the following closure
+    this.tracker.set('sendHitTask', function(model) {
+      var payLoad = model.get('hitPayload');
 
-				// replace values if they are present, delete from data if they are set to null
-        var fields = this.fields;
-
-				var keys = Object.keys(fields);
-
-				keys.forEach(function(key) {
-				    if(typeof fields[key] != "undefined") {
-				      if(fields[key] == null) {
-				          delete data[key];
-									// this.debugMessage('info', 'Removed key' + key + ' with value' + data[key] + " from payload");
-				      } else {
-								prevValue = data[key];
-								data[key] = fields[key];
-								// this.debugMessage('info', 'For key' + key + ' changed value ' + oldValue + ' to '  + data[key] + " in payload");
-				      }
-				    }
-				});
-
-				// Object.keys so not to enumerate properties in the prototype  chain
-        var newPayload = Object.keys(data).map(function(key) {
-            return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]);
-        }).join('&');
-
-        return newPayload;
-    }
-
-    /**
-     * Displays a debug message in the console, if debugging is enabled.
-     */
-    DualTracking.prototype.debugMessage = function(type, message) {
-        if (!this.isDebug) return;
-        if (arguments.length == 1) {
-            message = arguments[0];
-            type = "debug";
+      // huge payloads - e.g. if you do EEC with large product lists - are better sent via
+      // xhr post request. AFAIK the original request selects best transport method automatically
+      if (that.debug && that.transport != "xhr") {
+        var len = lengthInUtf8Bytes(payload);
+        if (len > 2047) {
+          that.debugMessage('info', 'Huge payload ( ~' + len + ' chars), consider setting transport to xhr');
         }
+      }
 
-        console[type]('[DualTracking]', message);
-    };
+      // send unmodified request to original tracker
+      originalSendHitTask(model);
 
-    /**
-		 * from here http://stackoverflow.com/a/5515960/761212
-		 */
-		DualTracking.prototype.lengthInUtf8Bytes = function(str) {
-		  // Matches only the 10.. bytes that are non-initial characters in a multi-byte sequence.
-		  var m = encodeURIComponent(str).match(/%[89ABab]/g);
-		  return str.length + (m ? m.length : 0);
-		}
+      // get the (modified) payload for the duplicate tracker
+      var data = that.deconstructPayload(payLoad);
+      var newPayload = that.reconstructPayload(data);
 
-    providePlugin('dualtracking', DualTracking);
+      if (that.transport == "image") {
+        var i = new Image(1, 1);
+        i.src = [that.gaEndpoint, newPayload].join("?");
+        i.onload = function() {
+          that.debugMessage('info', 'Image request sent');
+          return;
+        }
+      } else if (that.transport == "beacon") { //  TODO send newPayload as data, not via the url
+        navigator.sendBeacon([that.gaEndpoint, newPayload].join("?"), '');
+        that.debugMessage('info', 'Beacon sent');
+      } else if (that.transport == "xhr") {
+
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', that.gaEndpoint, true);
+        xhr.send(newPayload);
+
+        // evaluate async response
+        xhr.onload = function() {
+          var response = xhr.response;
+          if (xhr.response.length == 0) {
+            that.debugMessage('error', 'Empty response');
+          } else {
+            that.debugMessage('info', 'XHR request sent');
+          }
+        };
+        // if it did not work at all
+        xhr.onerror = function(e) {
+          that.debugMessage('error', 'Network error, no data sent');
+        };
+      }
+    });
+  }
+
+  /**
+   * disassemble the models' payload into key/value pairs
+   */
+  DualTracking.prototype.deconstructPayload = function(payLoad) {
+
+    that.debugMessage("debug", "Running deconstructPayload");
+
+    // remove leading question mark, split by ampersand and map to
+    // function that splits into key/value pairs
+    var data = (payLoad).replace(/(^\?)/, '').split("&").map(function(n) {
+      return n = n.split("="), this[n[0]] = n[1], this
+    }.bind({}))[0];
+
+    return data;
+  }
+
+  /**
+   * reassemble a payload package after overwriting the configured values
+   * values for the duplicate tracker
+   */
+  DualTracking.prototype.reconstructPayload = function(data) {
+    // setting the property id for the duplicate tracker
+    data.tid = this.property;
+
+    // replace values if they are present, delete from data if they are set to null
+    var fields = this.fields;
+    var keys = Object.keys(fields);
+    keys.forEach(function(key) {
+      if (typeof fields[key] != "undefined") {
+        if (fields[key] == null) {
+          delete data[key];
+        } else {
+          prevValue = data[key];
+          data[key] = fields[key];
+        }
+      }
+    });
+
+    // Object.keys so not to enumerate properties in the prototype  chain
+    var newPayload = Object.keys(data).map(function(key) {
+      return encodeURIComponent(key) + '=' + encodeURIComponent(data[key]);
+    }).join('&');
+
+    return newPayload;
+  }
+
+  /**
+   * Displays a debug message in the console, if debugging is enabled.
+   */
+  DualTracking.prototype.debugMessage = function(type, message) {
+    if (!this.isDebug) return;
+    if (arguments.length == 1) {
+      message = arguments[0];
+      type = "debug";
+    }
+
+    console[type]('[DualTracking]', message);
+  };
+
+  /**
+   * from here http://stackoverflow.com/a/5515960/761212
+   */
+  DualTracking.prototype.lengthInUtf8Bytes = function(str) {
+    // Matches only the 10.. bytes that are non-initial characters in a multi-byte sequence.
+    var m = encodeURIComponent(str).match(/%[89ABab]/g);
+    return str.length + (m ? m.length : 0);
+  }
+
+  providePlugin('dualtracking', DualTracking);
 })();


### PR DESCRIPTION
- I added an xhr method to the transports method (needs more work)
- I added a way to exlude fields from the payload for the secondary tracking call
- Since this uses stuff not available in older browsers (Object.keys, array.map, array.indexOf, foreach) I included the respective polyfills
- I reorganized the code a bit to avoid one giant "god function"

Changes might be a bit too extensive, when in doubt you can always pick and choose :-)
